### PR TITLE
Fix open-terminal example

### DIFF
--- a/examples/open-terminal.py
+++ b/examples/open-terminal.py
@@ -1,23 +1,21 @@
 # This example is contributed by Martin Enlund
 import os
-import urllib
+import urllib.parse
 
 import gi
 gi.require_version('GConf', '2.0')
 from gi.repository import Nautilus, GObject, GConf
 
-TERMINAL_KEY = '/desktop/gnome/applications/terminal/exec'
 
 class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
     def __init__(self):
         self.client = GConf.Client.get_default()
         
     def _open_terminal(self, file):
-        filename = urllib.unquote(file.get_uri()[7:])
-        terminal = self.client.get_string(TERMINAL_KEY)
+        filename = urllib.parse.unquote(file.get_uri()[7:])
 
         os.chdir(filename)
-        os.system('%s &' % terminal)
+        os.system('gnome-terminal')
         
     def menu_activate_cb(self, menu, file):
         self._open_terminal(file)

--- a/examples/open-terminal.py
+++ b/examples/open-terminal.py
@@ -1,6 +1,11 @@
 # This example is contributed by Martin Enlund
 import os
-import urllib.parse
+
+# Import unquote, moved to 'urllib.parse' in Python 3
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urllib import unquote
 
 import gi
 gi.require_version('GConf', '2.0')
@@ -12,7 +17,7 @@ class OpenTerminalExtension(Nautilus.MenuProvider, GObject.GObject):
         self.client = GConf.Client.get_default()
         
     def _open_terminal(self, file):
-        filename = urllib.parse.unquote(file.get_uri()[7:])
+        filename = unquote(file.get_uri()[7:])
 
         os.chdir(filename)
         os.system('gnome-terminal')


### PR DESCRIPTION
# Description
For me, the provided open-terminal example did not work. In Python 3, the used ``unquote`` from ``urllib`` moved to ``urllib.parse``. I have updated the example so it should now work with both Python 2 and 3.

- Replace urllib with urllib.parse
- Update terminal path