### PR TITLE
Allow to override build date

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -74,7 +74,7 @@ REFERENCE_DEPS = 	\
 if ENABLE_GTK_DOC
 
 reference/builddate.xml: $(REFERENCE_DEPS)
-	$(PYTHON) -c 'import datetime; print(datetime.date.today())' > $@
+	$(PYTHON) -c "import datetime; import os; import time; print(datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))).date())" > $@
 
 $(HTML_DATA): $(REFERENCE_DEPS) reference/builddate.xml
 	$(GTKDOC_MKHTML) \


### PR DESCRIPTION
Allow to override build date
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

also tracked in https://bugzilla.gnome.org/show_bug.cgi?id=795063